### PR TITLE
[OpenSBI] VexRiscv implementation.

### DIFF
--- a/patches/opensbi/vexriscv/config.mk
+++ b/patches/opensbi/vexriscv/config.mk
@@ -6,6 +6,8 @@ platform-cflags-y =
 platform-asflags-y =
 platform-ldflags-y =
 
+# RISC-V GCC options are described here:
+#   https://gcc.gnu.org/onlinedocs/gcc/RISC-V-Options.html#RISC-V-Options
 PLATFORM_RISCV_XLEN = 32
 PLATFORM_RISCV_ABI = ilp32
 PLATFORM_RISCV_ISA = rv32ima

--- a/patches/opensbi/vexriscv/config.mk
+++ b/patches/opensbi/vexriscv/config.mk
@@ -1,0 +1,24 @@
+# vim: tabstop=8 shiftwidth=8 noexpandtab:
+
+# Compiler flags.
+platform-cppflags-y =
+platform-cflags-y =
+platform-asflags-y =
+platform-ldflags-y =
+
+PLATFORM_RISCV_XLEN = 32
+PLATFORM_RISCV_ABI = ilp32
+PLATFORM_RISCV_ISA = rv32ima
+PLATFORM_RISCV_CODE_MODEL = medany
+
+# Firmware load address configuration.
+FW_TEXT_START=0x80000000
+
+# We use the jump firmware configuration.
+FW_JUMP=y
+
+# This needs to be 4MB aligned for 32-bit system.
+FW_JUMP_ADDR=$(shell printf "0x%X" $$(($(FW_TEXT_START) + 0x400000)))
+
+# Use the same address as QEMU.
+FW_JUMP_FDT_ADDR=$(shell printf "0x%X" $$(($(FW_TEXT_START) + 0x2200000)))

--- a/patches/opensbi/vexriscv/litex.c
+++ b/patches/opensbi/vexriscv/litex.c
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2020 Florent Kermarrec <florent@enjoy-digital.fr>
+ * Copyright (c) 2020 Dolu1990 <charles.papon.90@gmail.com>
+ *
+ */
+
+/* MODIFIED */
+
+#include <stdint.h>
+
+#define UART_EV_TX	0x1
+#define UART_EV_RX	0x2
+
+/* NOTE: keep this synchronized with the CSR map. */
+#define UART_CSR_BASE		0xf0001000L
+
+#define UART_RXTX_CSR		(UART_CSR_BASE + 0x000)
+#define UART_TXFULL_CSR		(UART_CSR_BASE + 0x004)
+#define UART_EV_PENDING_CSR	(UART_CSR_BASE + 0x010)
+#define UART_TXEMPTY_CSR	(UART_CSR_BASE + 0x018)
+#define UART_RXFULL_CSR		(UART_CSR_BASE + 0x01c)
+
+#define MMPTR(a) (*((volatile uint32_t *)(a)))
+
+static inline void csr_write_simple(unsigned long v, unsigned long a)
+{
+	MMPTR(a) = v;
+}
+
+static inline unsigned long csr_read_simple(unsigned long a)
+{
+	return MMPTR(a);
+}
+
+static inline uint8_t uart_rxtx_read(void) {
+	return csr_read_simple(UART_RXTX_CSR);
+}
+
+static inline void uart_rxtx_write(uint8_t v) {
+	csr_write_simple(v, UART_RXTX_CSR);
+}
+
+static inline uint8_t uart_txfull_read(void) {
+	return csr_read_simple(UART_TXFULL_CSR);
+}
+
+static inline uint8_t uart_rxempty_read(void) {
+	return csr_read_simple(UART_TXEMPTY_CSR);
+}
+
+static inline void uart_ev_pending_write(uint8_t v) {
+	csr_write_simple(v, UART_EV_PENDING_CSR);
+}
+
+static inline uint8_t uart_rxfull_read(void) {
+	return csr_read_simple(UART_RXFULL_CSR);
+}
+
+void vex_putc(char c){
+	while (uart_txfull_read());
+	uart_rxtx_write(c);
+	uart_ev_pending_write(UART_EV_TX);
+}
+
+int vex_getc(void){
+	char c;
+	if (uart_rxempty_read())
+		return -1;
+	c = uart_rxtx_read();
+	uart_ev_pending_write(UART_EV_RX);
+	return c;
+}

--- a/patches/opensbi/vexriscv/litex.h
+++ b/patches/opensbi/vexriscv/litex.h
@@ -1,0 +1,7 @@
+#ifndef _LITEX_H_
+#define _LITEX_H_
+
+void vex_putc(char c);
+int vex_getc(void);
+
+#endif /* !_LITEX_H_ */

--- a/patches/opensbi/vexriscv/objects.mk
+++ b/patches/opensbi/vexriscv/objects.mk
@@ -1,0 +1,2 @@
+platform-objs-y += platform.o
+platform-objs-y += litex.o

--- a/patches/opensbi/vexriscv/platform.c
+++ b/patches/opensbi/vexriscv/platform.c
@@ -1,0 +1,137 @@
+#include <sbi/riscv_asm.h>
+#include <sbi/riscv_encoding.h>
+#include <sbi/sbi_console.h>
+#include <sbi/sbi_const.h>
+#include <sbi/sbi_platform.h>
+#include <sbi/sbi_string.h>
+#include <sbi/sbi_types.h>
+#include <sbi_utils/ipi/aclint_mswi.h>
+#include <sbi_utils/irqchip/plic.h>
+#include <sbi_utils/serial/uart8250.h>
+#include <sbi_utils/timer/aclint_mtimer.h>
+
+#include "litex.h"
+
+/*
+ * PLIC parameters.
+ */
+#define VEX_PLIC_ADDR		0xf1000000
+#define VEX_PLIC_NUM_SOURCES	16
+#define VEX_HART_COUNT		1
+
+/*
+ * CLINT parameters.
+ */
+#define VEX_CLINT_ADDR		0xf0010000
+#define VEX_ACLINT_MTIMER_FREQ	1000000
+#define VEX_ACLINT_MSWI_ADDR	(VEX_CLINT_ADDR + CLINT_MSWI_OFFSET)
+#define VEX_ACLINT_MTIMER_ADDR	(VEX_CLINT_ADDR + CLINT_MTIMER_OFFSET)
+
+static struct plic_data plic = {
+	.addr = VEX_PLIC_ADDR,
+	.num_src = VEX_PLIC_NUM_SOURCES,
+};
+
+static struct aclint_mswi_data mswi = {
+	.addr = VEX_ACLINT_MSWI_ADDR,
+	.size = ACLINT_MSWI_SIZE,
+	.first_hartid = 0,
+	.hart_count = VEX_HART_COUNT,
+};
+
+static struct aclint_mtimer_data mtimer = {
+	.mtime_freq = VEX_ACLINT_MTIMER_FREQ,
+	.mtime_addr = VEX_ACLINT_MTIMER_ADDR + ACLINT_DEFAULT_MTIME_OFFSET,
+	.mtime_size = ACLINT_DEFAULT_MTIME_SIZE,
+	.mtimecmp_addr = VEX_ACLINT_MTIMER_ADDR +
+			 ACLINT_DEFAULT_MTIMECMP_OFFSET,
+	.mtimecmp_size = ACLINT_DEFAULT_MTIMECMP_SIZE,
+	.first_hartid = 0,
+	.hart_count = VEX_HART_COUNT,
+	.has_64bit_mmio = TRUE,
+};
+
+static struct sbi_console_device console = {
+	.console_putc = vex_putc,
+	.console_getc = vex_getc,
+};
+
+static int vex_early_init(bool cold_boot)
+{
+	return 0;
+}
+
+static int vex_final_init(bool cold_boot)
+{
+	return 0;
+}
+
+static int vex_console_init(void)
+{
+	const char *name = "LiteX UART";
+	size_t size = MIN(sbi_strlen(name), sizeof(console.name) - 1);
+	sbi_memcpy(console.name, name, size);
+	sbi_console_set_device(&console);
+	return 0;
+}
+
+static int vex_irqchip_init(bool cold_boot)
+{
+	u32 hartid = current_hartid();
+	int ret;
+
+	if (cold_boot) {
+		ret = plic_cold_irqchip_init(&plic);
+		if (ret)
+			return ret;
+	}
+
+	return plic_warm_irqchip_init(&plic, 2 * hartid, 2 * hartid + 1);
+}
+
+static int vex_ipi_init(bool cold_boot)
+{
+	int ret;
+
+	if (cold_boot) {
+		ret = aclint_mswi_cold_init(&mswi);
+		if (ret)
+			return ret;
+	}
+
+	return aclint_mswi_warm_init();
+}
+
+static int vex_timer_init(bool cold_boot)
+{
+	int ret;
+
+	if (cold_boot) {
+		ret = aclint_mtimer_cold_init(&mtimer, NULL);
+		if (ret)
+			return ret;
+	}
+
+	return aclint_mtimer_warm_init();
+}
+
+/*
+ * VexRiscv platform description.
+ */
+const struct sbi_platform_operations platform_ops = {
+	.early_init 	= vex_early_init,
+	.final_init	= vex_final_init,
+	.console_init	= vex_console_init,
+	.irqchip_init	= vex_irqchip_init,
+	.ipi_init	= vex_ipi_init,
+	.timer_init	= vex_timer_init,
+};
+
+const struct sbi_platform platform = {
+	.opensbi_version	= OPENSBI_VERSION,
+	.platform_version	= SBI_PLATFORM_VERSION(0x0, 0x01),
+	.name			= "LiteX VexRiscv",
+	.features		= SBI_PLATFORM_DEFAULT_FEATURES,
+	.hart_count		= VEX_HART_COUNT,
+	.platform_ops_addr	= (unsigned long)&platform_ops,
+};


### PR DESCRIPTION
We use OpenSBI as the SBI implementation for VexRiscv platform. However, the default implementation doesn't support VexRiscv.