### PR TITLE
Update Renode repl and resc files.

### DIFF
--- a/patches/renode/platforms/cpus/litex_vexriscv_mimiker.repl
+++ b/patches/renode/platforms/cpus/litex_vexriscv_mimiker.repl
@@ -1,54 +1,30 @@
-/* VexRiscv RENODE platform description. */
-
-/*
- * RISC-V hart.
- */
 cpu: CPU.VexRiscv @ sysbus
     cpuType: "rv32ima"
-    hartId: 0
     privilegeArchitecture: PrivilegeArchitecture.Priv1_10
+    builtInIrqController: false
     timeProvider: clint
 
-/*
- * Memory Map.
- */
 rom: Memory.MappedMemory @ sysbus 0x0
-    size: 0x00008000
+    size: 0x000010000
 
 sram: Memory.MappedMemory @ sysbus 0x10000000
-    size: 0x00008000
+    size: 0x00002000
 
-ram: Memory.MappedMemory @ sysbus 0x80000000
-    size: 0x40000000
-
-/*
- * LiteX CSR space.
- */
+ram: Memory.MappedMemory @ sysbus 0x40000000
+    size: 0x10000000
 
 soc_controller: Miscellaneous.LiteX_SoC_Controller @ sysbus 0xf0000000
 
 uart0: UART.LiteX_UART @ sysbus 0xf0001000
-    IRQ -> plic@0
-
-/* 0xf0002000 - 0xf0010000: unused. */
-
-/*
- * Other peripherals.
- */
+    IRQ -> plic@1
 
 clint: IRQControllers.CoreLevelInterruptor @ sysbus 0xf0010000
-    frequency: 1000000
+    frequency: 100000000
+    numberOfTargets: 1
     [0, 1] -> cpu@[3, 7]
 
-/* 0xf0020000 - 0xf1000000: unused */
-
-plic: IRQControllers.PlatformLevelInterruptController @ sysbus 0xf1000000
-    numberOfSources: 16
+plic: IRQControllers.PlatformLevelInterruptController @ sysbus 0xf0c00000
+    numberOfSources: 31
     numberOfContexts: 2
     prioritiesEnabled: false
-    [0, 1] -> cpu@[11, 9]
-
-/* 
- * TODO: Manage unused ranges for additional peripherals
- * including USB controller, eMMC controller, GPIO, etc.
- */
+    [0,1] -> cpu@[11, 9]

--- a/patches/renode/scripts/single-node/litex_vexriscv_mimiker.resc
+++ b/patches/renode/scripts/single-node/litex_vexriscv_mimiker.resc
@@ -1,4 +1,4 @@
-$name="vexriscv"
+$name="litex-vexriscv-mimiker"
 
 using sysbus
 
@@ -7,21 +7,19 @@ machine LoadPlatformDescription @platforms/cpus/litex_vexriscv_mimiker.repl
 
 ### Launch script uses socket terminal integration for UARTs.
 
-### TODO: OpenSBI image should be automatically downloaded
-### from Mimiker RISC-V hardware repository.
-$opensbi=@sys/fw_jump.bin
+$opensbi=@fw_jump.bin
 $kernel=@sys/mimiker.img
-$dtb=@sys/dts/vexriscv.dtb
+$dtb=@sys/dts/litex-riscv.dtb
 $initrd=@initrd.cpio
 
 macro reset
 """
-    sysbus LoadBinary $opensbi 0x80000000
-    sysbus LoadBinary $kernel  0x80400000
-    sysbus LoadBinary $dtb     0x82200000
-    sysbus LoadBinary $initrd  0x83000000
+    sysbus LoadBinary $kernel  0x40000000
+    sysbus LoadBinary $dtb     0x40ef0000
+    sysbus LoadBinary $opensbi 0x40f00000
+    sysbus LoadBinary $initrd  0x42000000
 
-    cpu PC 0x80000000
+    cpu PC 0x40f00000
 """
 
 runMacro $reset


### PR DESCRIPTION
Although LiteX can generate Renode platform description based on the build configuration, the generating script is obsolete.