### PR TITLE
Add CLINT to dtb.

### DIFF
--- a/litex/.gitignore
+++ b/litex/.gitignore
@@ -5,3 +5,4 @@
 /images/opensbi.bin
 /images/rootfs.cpio
 /images/rv32.dtb
+clint.dtbo

--- a/litex/clint.dts
+++ b/litex/clint.dts
@@ -1,0 +1,10 @@
+/dts-v1/;
+/plugin/;
+
+&{/soc} {
+    clint@f0010000 {
+        compatible="riscv,clint0";
+        interrupts-extended = <&L0 7 &L0 3>;
+        reg = <0xf0010000 0x10000>;
+    };
+};

--- a/litex/soc_mimiker.py
+++ b/litex/soc_mimiker.py
@@ -72,17 +72,17 @@ def SoCMimiker(soc_cls, **kwargs):
             dts = os.path.join("build", board_name, "{}.dts".format(board_name))
             dtb = os.path.join("build", board_name, "{}.dtb".format(board_name))
             subprocess.check_call(
-                "dtc {} -O dtb -o {} {}".format("-@" if symbols else "", dtb, dts), shell=True)
+                "dtc -@ -O dtb -o clint.dtbo clint.dts", shell=True)
+            subprocess.check_call(
+                "dtc -@ -O dtb -o {} {}".format(dtb, dts), shell=True)
 
         # DTB combination --------------------------------------------------------------------------
         def combine_dtb(self, board_name, overlays=""):
             dtb_in = os.path.join("build", board_name, "{}.dtb".format(board_name))
             dtb_out = os.path.join("images", "rv32.dtb")
-            if overlays == "":
-                shutil.copyfile(dtb_in, dtb_out)
-            else:
-                subprocess.check_call(
-                    "fdtoverlay -i {} -o {} {}".format(dtb_in, dtb_out, overlays), shell=True)
+            overlays += " clint.dtbo"
+            subprocess.check_call(
+                "fdtoverlay -i {} -o {} {}".format(dtb_in, dtb_out, overlays), shell=True)
 
         # REPL generation --------------------------------------------------------------------------
         def generate_repl(self, board_name):


### PR DESCRIPTION
For some reasons, the dtb generating script doesn't include CLINT. However, CLINT is assumed by Mimiker.